### PR TITLE
propose wording with clearer meaning

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -21,7 +21,7 @@
         "message": "File conflicts action"
     },
     "optSettingsConflictActionUniquify": {
-        "message": "Uniquify"
+        "message": "Save with other name"
     },
     "optSettingsConflictActionOverwrite": {
         "message": "Overwrite"


### PR DESCRIPTION
"Uniquify" is not common English and does not match the original Japanese meaning. Hence proposing this change.
You may also consider using "Save As New"