### PR TITLE
fix capitalizations

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -29,8 +29,8 @@
             <label i18n="settingsConvertMode"></label>
             <select class="ui-full-width" id="convertMode">
                 <option value="none">None</option>
-                <option value="jpeg">Jpeg</option>
-                <option value="png">Png</option>
+                <option value="jpeg">JPEG</option>
+                <option value="png">PNG</option>
                 <option value="webp">WebP</option>
             </select>
             <label i18n="settingsConvertQuality"></label>
@@ -38,8 +38,8 @@
             <label i18n="settingsUgoiraMode"></label>
             <select class="ui-full-width" id="ugoiraMode">
                 <option value="zip">None(Zip)</option>
-                <option value="gif">Gif</option>
-                <option value="apng">APng</option>
+                <option value="gif">GIF</option>
+                <option value="apng">APNG</option>
                 <option value="webp">WebP</option>
             </select>
             <label i18n="settingsUgoiraQuality"></label>


### PR DESCRIPTION
GIF, PNG and APNG are shorthand using Initials. Hence ALL-CAPs should be used. Just minor issue so you may wait for other PR to accumulate before making a new release.