### PR TITLE
ZERO WIDTH SPACE (U+200B)のエスケープを追加

### DIFF
--- a/src/lib/px-background.js
+++ b/src/lib/px-background.js
@@ -536,7 +536,7 @@ export default class PxBackground {
     }
 
     static escape(str, flag) {
-        return str.replace(flag ? /([/?*:|"<>~\\])/g : /([/?*:|"<>~])/g, PxBackground.toFull);
+        return str.replace(flag ? /([/?*:|"<>~\\])/g : /([/?*:|"<>~])/g, PxBackground.toFull).replaceAll("\u200b", '');
     }
 
     static getImageElement(url) {


### PR DESCRIPTION
ダウンロードファイル名にU+200B (ZERO WIDTH SPACE) が含まれているとダウンロードに失敗するようで、
ユーザー名がU+200Bの以下のユーザーのイラストがダウンロードできなかったため、エスケープを追加しました。
https://www.pixiv.net/users/9875687